### PR TITLE
fix: Change quotes for rpm-ostree installation

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -215,7 +215,7 @@ These are user-maintained packages and not official Fedora packages.
 Add the copr repository to your system:
 
 ```sh
-echo -e "
+echo -e '
 [copr:copr.fedorainfracloud.org:pgdev:ghostty]
 name=Copr repo for Ghostty owned by pgdev
 baseurl=https://download.copr.fedorainfracloud.org/results/pgdev/ghostty/fedora-$releasever-$basearch/
@@ -225,7 +225,7 @@ gpgcheck=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/pgdev/ghostty/pubkey.gpg
 repo_gpgcheck=0
 enabled=1
-enabled_metadata=1" | sudo tee /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:pgdev:ghostty.repo > /dev/null
+enabled_metadata=1' | sudo tee /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:pgdev:ghostty.repo > /dev/null
 ```
 
 After adding the repository, install Ghostty:


### PR DESCRIPTION
The current documentation leads to create a `.repo` file with the content:
```ini
[copr:copr.fedorainfracloud.org:pgdev:ghostty]
name=Copr repo for Ghostty owned by pgdev
baseurl=https://download.copr.fedorainfracloud.org/results/pgdev/ghostty/fedora--/
type=rpm-md
skip_if_unavailable=True
gpgcheck=1
gpgkey=https://download.copr.fedorainfracloud.org/results/pgdev/ghostty/pubkey.gpg
repo_gpgcheck=0
enabled=1
enabled_metadata=1' | sudo tee /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:pgdev:ghostty.repo > /dev/null
```
Note that the correct `baseurl` must be 
```ini
baseurl=https://download.copr.fedorainfracloud.org/results/pgdev/ghostty/fedora-$releasever-$basearch/
```
The double quotes evaluate the `$releasever` and `$basearch` values which is normally empty. This variables are used and evaluated by the `rpm-ostree` system and must be present as a template URL.